### PR TITLE
fix: Support slug fields for includeFromReference

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ If you already have a sanity schema that contains a tag-like structure and want 
 }
 ```
 
+To use the title and slug fields from the referenced schema type, set the custom field mappings:
+```javascript
+{
+  // ...
+  customLabel: 'title'
+  customValue: 'slug.current'
+  // ...
+}
+```
+
 ### includeFromRelated
 
 `default: false`

--- a/README.md
+++ b/README.md
@@ -133,10 +133,13 @@ To use the title and slug fields from the referenced schema type, set the custom
 {
   // ...
   customLabel: 'title'
-  customValue: 'slug.current'
+  customValue: 'slug'
   // ...
 }
 ```
+
+The plugin automatically handles slug objects by extracting the `.current` value, so you can use `'slug'` directly.
+
 
 ### includeFromRelated
 

--- a/src/utils/observables.ts
+++ b/src/utils/observables.ts
@@ -169,7 +169,7 @@ export const getTagsFromReference = ({
   const query = `
   *[ _type == $document && defined(@[$customLabel]) && defined(@[$customValue])] {
     _id,
-    "value": @[$customValue],
+    "value": coalesce(@[$customValue].current,@[$customValue]),
     "label": @[$customLabel]
   }
   `
@@ -226,7 +226,7 @@ export const getTagsFromRelated = ({
       (!$isMulti && defined(@[$field][$customLabel]) && defined(@[$field][$customValue])) ||
       ($isMulti && defined(@[$field][]->[$customLabel]) && defined(@[$field][]->[$customValue])) ||
       ($isMulti && defined(@[$field][][$customLabel]) && defined(@[$field][][$customValue]))
-    ) 
+    )
   ][$field]
   `
 


### PR DESCRIPTION
- If field is a slug, get .current, else get the field
- Add example for using slug with customValue